### PR TITLE
feat: creación de entidades con claves primarias y relaciones

### DIFF
--- a/backend/recrea/pom.xml
+++ b/backend/recrea/pom.xml
@@ -54,6 +54,12 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.18.30</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/entidades/Clasificacion.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/entidades/Clasificacion.java
@@ -1,0 +1,60 @@
+package com.recreadejuerga.recrea.entidades;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerator;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Entity
+@Table(name = "clasificaciones")
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+public class Clasificacion {
+    @Id
+    @Column(name = "equipo_id", nullable = false)
+    private UUID id;
+
+    @OneToOne
+    @MapsId
+    @JoinColumn(name = "equipo_id", foreignKey = @ForeignKey(name = "fk_equipo_clasificacion"))
+    private Equipo equipo;
+
+    @Column(name = "posicion")
+    private Integer posicion;
+
+    @Column(name = "puntos")
+    private Integer puntos = 0;
+
+    @Column(name = "partidos_jugados")
+    private Integer partidosJugados = 0;
+
+    @Column(name = "ganados")
+    private Integer ganados = 0;
+
+    @Column(name = "empatados")
+    private Integer empatados = 0;
+
+    @Column(name = "perdidos")
+    private Integer perdidos = 0;
+
+    @Column(name = "goles_favor")
+    private Integer golesFavor = 0;
+
+    @Column(name = "goles_contra")
+    private Integer golesContra = 0;
+
+    @Column(name = "diferencia_goles")
+    private Integer diferenciaGoles = 0;
+
+    @Column(name = "promedio_tf_tc", precision = 4, scale = 2)
+    private BigDecimal promedioTfTc;
+}

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/entidades/Equipo.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/entidades/Equipo.java
@@ -1,0 +1,42 @@
+package com.recreadejuerga.recrea.entidades;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.mapping.Constraint;
+import org.w3c.dom.Text;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "equipos")
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+public class Equipo {
+    @Id
+    private UUID id;
+
+    @OneToOne(mappedBy = "equipo", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Clasificacion clasificacion;
+
+    @Column(name = "nombre", unique = true ,nullable = false, length = 100)
+    private String nombre;
+
+    @Column(name = "url_logo", columnDefinition = "TEXT")
+    private String  url_logo;
+
+    @OneToMany(mappedBy = "equipoLocal", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Partido> partidosComoLocal = new ArrayList<>();
+
+    @OneToMany(mappedBy = "equipoVisitante", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Partido> partidosComoVisitante = new ArrayList<>();
+
+}

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/entidades/EstadisticasJugadorPartido.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/entidades/EstadisticasJugadorPartido.java
@@ -1,0 +1,44 @@
+package com.recreadejuerga.recrea.entidades;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "estadisticas_jugador_partido")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+public class EstadisticasJugadorPartido {
+    @EmbeddedId
+    private EstadisticasJugadorPartidoId id;
+
+    @ManyToOne
+    @MapsId
+    @JoinColumn(name = "jugador_id",foreignKey = @ForeignKey(name = "fk_jugador"))
+    private Jugador jugador;
+
+    @ManyToOne
+    @MapsId
+    @JoinColumn(name = "partido_id",foreignKey = @ForeignKey(name = "fk_partido"))
+    private Partido partido;
+
+    @Column(name = "goles")
+    private Integer goles = 0;
+
+    @Column(name = "asistencias")
+    private Integer asistencias = 0;
+
+    @Column(name = "amarilla")
+    private Boolean amarilla = false;
+
+    @Column(name = "roja")
+    private Boolean roja = false;
+
+    @Column(name = "portero")
+    private Boolean portero = false;
+}

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/entidades/EstadisticasJugadorPartidoId.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/entidades/EstadisticasJugadorPartidoId.java
@@ -1,0 +1,23 @@
+package com.recreadejuerga.recrea.entidades;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class EstadisticasJugadorPartidoId implements Serializable {
+
+    @Column(name = "jugador_id")
+    private UUID jugadorId;
+
+    @Column(name = "partido_id")
+    private UUID partidoId;
+}

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/entidades/Jugador.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/entidades/Jugador.java
@@ -1,0 +1,84 @@
+package com.recreadejuerga.recrea.entidades;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.*;
+
+@Entity
+@Table(name = "jugadores",
+        uniqueConstraints = {
+            @UniqueConstraint(name = "unique_dorsal_por_team", columnNames = {"equipo_id", "dorsal"})
+        })
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+public class Jugador {
+        @Id
+        @Column(name = "id", nullable = false)
+        private UUID id;
+
+        @Column(name = "nombre", nullable = false, length = 100)
+        private String nombre;
+
+        @Column(name = "apodo", length = 100)
+        private String apodo;
+
+        @Column(name = "dorsal", nullable = false)
+        private Integer dorsal;
+
+        @Column(name = "posicion", length = 50)
+        private String posicion;
+
+        @Column(name = "pie_dominante", length = 10)
+        private String pieDominante;
+
+        @Column(name = "goles_totales")
+        private Integer golesTotales = 0;
+
+        @Column(name = "asistencias_totales")
+        private Integer asistenciasTotales = 0;
+
+        @Column(name = "fortalezas", columnDefinition = "TEXT")
+        private String fortalezas;
+
+        @Column(name = "fecha_nacimiento")
+        private LocalDate fechaNacimiento;
+
+        @ManyToOne
+        @JoinColumn(name = "equipo_id", nullable = false, foreignKey = @ForeignKey(name = "fk_equipo"))
+        private Equipo equipo;
+
+        @OneToMany(mappedBy = "jugador", cascade = CascadeType.ALL, orphanRemoval = true)
+        private List<EstadisticasJugadorPartido> estadisticas= new ArrayList<>();
+
+        @OneToMany(mappedBy = "jugador", cascade = CascadeType.ALL, orphanRemoval = true)
+        private List<JugadorParecido> parecidos= new ArrayList<>();
+
+        @ManyToMany
+        @JoinTable(
+                name = "jugadores_nacionalidad",
+                joinColumns = @JoinColumn(name = "jugador_id"),
+                inverseJoinColumns = @JoinColumn(name = "nacionalidad_id")
+        )
+        private Set<Nacionalidad> nacionalidades = new HashSet<>();
+
+        @OneToMany(mappedBy = "mvp",cascade = CascadeType.ALL,orphanRemoval = true)
+        private List<Partido> partidosComoMvp= new ArrayList<>();
+
+        @Column(name = "foto_frontal", columnDefinition = "TEXT")
+        private String fotoFrontal;
+
+        @Column(name = "foto_tarjeta", columnDefinition = "TEXT")
+        private String fotoTarjeta;
+
+        @Column(name = "foto_pose", columnDefinition = "TEXT")
+        private String fotoPose;
+
+}

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/entidades/JugadorParecido.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/entidades/JugadorParecido.java
@@ -1,0 +1,25 @@
+package com.recreadejuerga.recrea.entidades;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "jugadores_parecidos")
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+public class JugadorParecido {
+    @EmbeddedId
+    private JugadorParecidoId id;
+
+    @ManyToOne
+    @MapsId("jugadorId")
+    @JoinColumn(name = "jugador_id", foreignKey = @ForeignKey(name = "fk_jugador"))
+    private Jugador jugador;
+}

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/entidades/JugadorParecidoId.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/entidades/JugadorParecidoId.java
@@ -1,0 +1,23 @@
+package com.recreadejuerga.recrea.entidades;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class JugadorParecidoId implements Serializable {
+
+    @Column(name = "jugador_id", nullable = false)
+    private UUID jugadorId;
+
+    @Column(name = "parecido", nullable = false, length = 100)
+    private String parecido;
+}

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/entidades/Nacionalidad.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/entidades/Nacionalidad.java
@@ -1,0 +1,35 @@
+package com.recreadejuerga.recrea.entidades;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "nacionalidades")
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+public class Nacionalidad {
+    @Id
+    @Column(name = "id", nullable = false)
+    private UUID id;
+
+    @Column(name = "nombre", nullable = false, unique = true, length = 100)
+    private String nombre;
+
+    @Column(name = "codigo_iso", nullable = false, unique = true, length = 2)
+    private String codigoIso;
+
+    @Column(name = "icono", length = 10)
+    private String icono;
+}

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/entidades/Partido.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/entidades/Partido.java
@@ -1,0 +1,54 @@
+package com.recreadejuerga.recrea.entidades;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "partidos",
+        uniqueConstraints = {
+        @UniqueConstraint(name = "partido_unico", columnNames = {"fecha","lugar"})
+        })
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+public class Partido {
+        @Id
+        @Column(name = "id", nullable = false)
+        private UUID id;
+
+        @Column(name = "fecha", nullable = false)
+        private LocalDateTime fecha;
+
+        @Column(name = "lugar", nullable = false, length = 100)
+        private String lugar;
+
+        @Column(name = "estado", nullable = false, length = 20)
+        private String estado;
+
+        @ManyToOne
+        @JoinColumn(name = "equipo_local", foreignKey = @ForeignKey(name = "fk_equipo_local"))
+        private Equipo equipoLocal;
+
+        @ManyToOne
+        @JoinColumn(name = "equipo_visitante", foreignKey = @ForeignKey(name = "fk_equipo_visitante"))
+        private Equipo equipoVisitante;
+
+        @Column(name = "goles_local")
+        private Integer golesLocal;
+
+        @Column(name = "goles_visitante")
+        private Integer golesVisitante;
+
+        @ManyToOne
+        @JoinColumn(name = "mvp_id", foreignKey = @ForeignKey(name = "fk_mvp"))
+        private Jugador mvp;
+}


### PR DESCRIPTION
Este Pull Request añade todas las entidades principales del dominio con sus respectivas claves primarias (UUID) y relaciones entre ellas.

#Entidades incluidas:
- Clasificacion
- Equipo
- Jugador
- JugadorParecido
- EstadisticasJugadorPartido
- Nacionalidad
- Partido

# Relaciones implementadas:
- @OneToOne entre Equipo y Clasificacion
- @ManyToOne entre Jugador y Equipo
- @ManyToMany entre Jugador y Nacionalidad
- @OneToMany desde Jugador hacia JugadorParecido y EstadisticasJugadorPartido
- @ManyToOne en Partido hacia Equipo (local/visitante) y Jugador (MVP)
- Claves primarias compuestas modeladas con @EmbeddedId y @MapsId

Todas las clases usan UUID como identificador y están anotadas con Lombok para reducir código repetitivo.