### PR TITLE
feat: implementación de la lógica completa para gestión de partidos

### DIFF
--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/controladores/JugadorParecidoControlador.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/controladores/JugadorParecidoControlador.java
@@ -165,10 +165,4 @@ public class JugadorParecidoControlador {
         jugadorParecidoServicio.eliminarParecido(id);
         return ResponseEntity.noContent().build();
     }
-
-
-
-
-
-
 }

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/controladores/PartidoControlador.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/controladores/PartidoControlador.java
@@ -1,0 +1,248 @@
+package com.recreadejuerga.recrea.controladores;
+
+import com.recreadejuerga.recrea.dtos.jugador.JugadorDTO;
+import com.recreadejuerga.recrea.dtos.partido.PartidoDTO;
+import com.recreadejuerga.recrea.dtos.partido.PartidoFormularioDTO;
+import com.recreadejuerga.recrea.servicios.PartidoServicio;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/Partidos")
+@Tag(name = "Partidos", description = "Gestión básica de los partidos")
+public class PartidoControlador {
+
+    @Autowired
+    private PartidoServicio partidoServicio;
+
+    @Operation(
+            summary = "Obtener todos los partidos de un equipo en concreto",
+            description = "Permite obtener la información de los partidos de un equipo si se le proporciona un equipo_id",
+            tags = {"parámetros","detalles"}
+    )
+    @ApiResponse(
+            description = "Información detallada de los partidos de un equipo ordenados de más antiguos a mas recientes", responseCode = "200",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PartidoDTO.class),
+                    examples = {
+                            @ExampleObject("""
+                                    [
+                                      {
+                                        "id": "8a7c0e4e-56e3-4f99-8fc4-1e3a5c3fae7d",
+                                        "fecha": "2025-06-15T20:30:00",
+                                        "lugar": "Estadio Santiago Bernabéu",
+                                        "estado": "Finalizado",
+                                        "equipoLocal": {
+                                          "id": "f1a8c0a2-d1ef-45b8-812b-6c9f6f8d3240",
+                                          "nombre": "Real Madrid CF",
+                                          "url_logo": "https://example.com/logos/realmadrid.png"
+                                        },
+                                        "equipoVisitante": {
+                                          "id": "b2b9d3f4-45cb-43de-a1de-8f4fae3f2f2e",
+                                          "nombre": "FC Barcelona",
+                                          "url_logo": "https://example.com/logos/barcelona.png"
+                                        },
+                                        "golesLocal": 3,
+                                        "golesVisitante": 2,
+                                        "mvp": {
+                                          "id": "c4f3e1a8-9880-42f5-8cf7-56464e88888a",
+                                          "nombre": "Jude Bellingham",
+                                          "apodo": "Belli",
+                                          "dorsal": 5,
+                                          "equipoId": "f1a8c0a2-d1ef-45b8-812b-6c9f6f8d3240"
+                                        }
+                                      },
+                                      {
+                                        "id": "ae934cfa-bbfc-4e01-8ef1-0bfa27a6ed00",
+                                        "fecha": "2025-06-20T18:00:00",
+                                        "lugar": "Estadio Wanda Metropolitano",
+                                        "estado": "Pendiente",
+                                        "equipoLocal": {
+                                          "id": "c1d4e9f2-1e54-4e8a-b97f-15fbb2cb5529",
+                                          "nombre": "Atlético de Madrid",
+                                          "url_logo": "https://example.com/logos/atletico.png"
+                                        },
+                                        "equipoVisitante": {
+                                          "id": "d4c8e7a3-9b43-4201-a3f7-8e42f6c5e7f2",
+                                          "nombre": "Sevilla FC",
+                                          "url_logo": "https://example.com/logos/sevilla.png"
+                                        },
+                                        "golesLocal": null,
+                                        "golesVisitante": null,
+                                        "mvp": null
+                                      }
+                                    ]
+                                    """)
+                    }
+            )
+    )
+    @GetMapping("/{equipo_id}")
+    public ResponseEntity<List<PartidoDTO>> getPartidosDeUnEquipo(@Parameter(description = "Identificador del equipo") @PathVariable UUID equipo_id){
+        List<PartidoDTO> partidosEquipo= partidoServicio.getPartidosDeUnEquipo(equipo_id);
+        return ResponseEntity.ok(partidosEquipo);
+    }
+
+    @Operation(
+            summary = "Para insertar un partido en la base de datos",
+            description = "Permite insertar un partido proporcionando un DTO con los datos",
+            tags = {"parámetros","creación"}
+    )
+    @ApiResponse(
+            description = "El partido insertado en la base de datos", responseCode = "200",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PartidoDTO.class),
+                    examples = {
+                            @ExampleObject("""
+                                    {
+                                      "id": "8a7c0e4e-56e3-4f99-8fc4-1e3a5c3fae7d",
+                                      "fecha": "2025-06-15T20:30:00",
+                                      "lugar": "Estadio Santiago Bernabéu",
+                                      "estado": "Finalizado",
+                                      "equipoLocal": {
+                                        "id": "f1a8c0a2-d1ef-45b8-812b-6c9f6f8d3240",
+                                        "nombre": "Real Madrid CF",
+                                        "url_logo": "https://example.com/logos/realmadrid.png"
+                                      },
+                                      "equipoVisitante": {
+                                        "id": "b2b9d3f4-45cb-43de-a1de-8f4fae3f2f2e",
+                                        "nombre": "FC Barcelona",
+                                        "url_logo": "https://example.com/logos/barcelona.png"
+                                      },
+                                      "golesLocal": 3,
+                                      "golesVisitante": 2,
+                                      "mvp": {
+                                        "id": "c4f3e1a8-9880-42f5-8cf7-56464e88888a",
+                                        "nombre": "Jude Bellingham",
+                                        "apodo": "Belli",
+                                        "dorsal": 5,
+                                        "equipoId": "f1a8c0a2-d1ef-45b8-812b-6c9f6f8d3240"
+                                      }
+                                    }
+                                    """)
+                    }
+            )
+    )
+    @PostMapping("/alta")
+    public ResponseEntity<PartidoDTO> crear(@io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "Partido a crear",
+            required = true,
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PartidoFormularioDTO.class),
+                    examples = {
+                            @ExampleObject("""
+                                    {
+                                      "fecha": "2025-06-22T21:00:00",
+                                      "lugar": "Estadio Benito Villamarín",
+                                      "estado": "Pendiente",
+                                      "equipoLocalId": "a4f0c3e8-1e35-4cb3-a7f1-d8d1c5b09f33",
+                                      "equipoVisitanteId": "b9d1f2e4-8f26-4db7-b918-9f8a78e932ef",
+                                      "golesLocal": 3,
+                                      "golesVisitante": 2,
+                                      "mvpId": "c4f3e1a8-9880-42f5-8cf7-56464e88888a"
+                                    }
+                                    """)
+                    }
+            )
+    ) @Valid @RequestBody PartidoFormularioDTO partido) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(partidoServicio.insertarPartido(partido));
+    }
+
+    @Operation(
+            summary = "Para modificar un partido en la base de datos",
+            description = "Permite editar un partido proporcionando un DTO con los datos y un id",
+            tags = {"parámetros","actualizar"}
+    )
+    @ApiResponse(
+            description = "El partido actualizado en la base de datos", responseCode = "200",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = JugadorDTO.class),
+                    examples = {
+                            @ExampleObject("""
+                                     {
+                                        "id": "8a7c0e4e-56e3-4f99-8fc4-1e3a5c3fae7d",
+                                        "fecha": "2025-06-15T20:30:00",
+                                        "lugar": "Estadio Santiago Bernabéu",
+                                        "estado": "Finalizado",
+                                        "equipoLocal": {
+                                          "id": "f1a8c0a2-d1ef-45b8-812b-6c9f6f8d3240",
+                                          "nombre": "Real Madrid CF",
+                                          "url_logo": "https://example.com/logos/realmadrid.png"
+                                        },
+                                        "equipoVisitante": {
+                                          "id": "b2b9d3f4-45cb-43de-a1de-8f4fae3f2f2e",
+                                          "nombre": "FC Barcelona",
+                                          "url_logo": "https://example.com/logos/barcelona.png"
+                                        },
+                                        "golesLocal": 3,
+                                        "golesVisitante": 2,
+                                        "mvp": {
+                                          "id": "c4f3e1a8-9880-42f5-8cf7-56464e88888a",
+                                          "nombre": "Jude Bellingham",
+                                          "apodo": "Belli",
+                                          "dorsal": 5,
+                                          "equipoId": "f1a8c0a2-d1ef-45b8-812b-6c9f6f8d3240"
+                                        }
+                                      }
+                                    """)
+                    }
+            )
+    )
+    @PutMapping("/{id}")
+    public ResponseEntity<PartidoDTO> editar(@io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "Partido para editar",
+            required = true,
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PartidoFormularioDTO.class),
+                    examples = {
+                            @ExampleObject("""
+                                    {
+                                      "fecha": "2025-06-22T21:00:00",
+                                      "lugar": "Estadio Benito Villamarín",
+                                      "estado": "Pendiente",
+                                      "equipoLocalId": "a4f0c3e8-1e35-4cb3-a7f1-d8d1c5b09f33",
+                                      "equipoVisitanteId": "b9d1f2e4-8f26-4db7-b918-9f8a78e932ef",
+                                      "golesLocal": 3,
+                                      "golesVisitante": 2,
+                                      "mvpId": "c4f3e1a8-9880-42f5-8cf7-56464e88888a"
+                                    }
+                                    """)
+                    }
+            )
+    ) @Valid @RequestBody PartidoFormularioDTO partido, @Parameter(description = "Identificador del partido") @PathVariable UUID id){
+        PartidoDTO actualizado = partidoServicio.modificarPartido(partido, id);
+        return ResponseEntity.ok(actualizado);
+    }
+
+
+    @Operation(
+            summary = "Para borrar un partido de la base de datos",
+            description = "Permite borrar un partido mediante un id",
+            tags = {"parámetros","eliminar"}
+    )
+    @ApiResponse(
+            description = "El partido eliminado en la base de datos", responseCode = "204"
+    )
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> eliminar(@Parameter(description = "Identificador del partido") @PathVariable UUID id){
+        partidoServicio.eliminarPartido(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/dtos/clasificacion/ClasificacionDTO.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/dtos/clasificacion/ClasificacionDTO.java
@@ -1,10 +1,7 @@
 package com.recreadejuerga.recrea.dtos.clasificacion;
 
 import com.recreadejuerga.recrea.dtos.equipo.EquipoDTO;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.math.BigDecimal;
 import java.util.UUID;
@@ -13,6 +10,7 @@ import java.util.UUID;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class ClasificacionDTO {
     private UUID id;
     private Integer puntos;

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/dtos/clasificacion/ClasificacionEditarDTO.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/dtos/clasificacion/ClasificacionEditarDTO.java
@@ -2,16 +2,14 @@ package com.recreadejuerga.recrea.dtos.clasificacion;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class ClasificacionEditarDTO {
 
     @NotNull

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/dtos/equipo/EquipoDTO.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/dtos/equipo/EquipoDTO.java
@@ -1,9 +1,6 @@
 package com.recreadejuerga.recrea.dtos.equipo;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.UUID;
 
@@ -11,6 +8,7 @@ import java.util.UUID;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class EquipoDTO {
     private UUID id;
     private String nombre;

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/dtos/equipo/EquipoFormularioDTO.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/dtos/equipo/EquipoFormularioDTO.java
@@ -1,16 +1,14 @@
 package com.recreadejuerga.recrea.dtos.equipo;
 
 import jakarta.validation.constraints.NotBlank;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.hibernate.validator.constraints.URL;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class EquipoFormularioDTO {
     @NotBlank(message = "El nombre no puede estar vacío")
     private String nombre;

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/dtos/jugador/JugadorDTO.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/dtos/jugador/JugadorDTO.java
@@ -2,10 +2,8 @@ package com.recreadejuerga.recrea.dtos.jugador;
 
 import com.recreadejuerga.recrea.dtos.equipo.EquipoDTO;
 import com.recreadejuerga.recrea.dtos.jugadorparecido.JugadorParecidoSimpleDTO;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
+
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
@@ -14,6 +12,7 @@ import java.util.UUID;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class JugadorDTO {
     private UUID id;
     private String nombre;

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/dtos/jugador/JugadorFormularioDTO.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/dtos/jugador/JugadorFormularioDTO.java
@@ -1,9 +1,7 @@
 package com.recreadejuerga.recrea.dtos.jugador;
 
 import jakarta.validation.constraints.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.util.UUID;
@@ -11,6 +9,8 @@ import java.util.UUID;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class JugadorFormularioDTO {
 
     @NotBlank(message = "El nombre es obligatorio")

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/dtos/jugador/JugadorSimpleDTO.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/dtos/jugador/JugadorSimpleDTO.java
@@ -1,0 +1,20 @@
+package com.recreadejuerga.recrea.dtos.jugador;
+
+import lombok.*;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class JugadorSimpleDTO {
+
+    private UUID id;
+    private String nombre;
+    private String apodo;
+    private Integer dorsal;
+    private UUID equipoId;
+
+}

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/dtos/jugadorparecido/JugadorParecidoDTO.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/dtos/jugadorparecido/JugadorParecidoDTO.java
@@ -1,10 +1,6 @@
 package com.recreadejuerga.recrea.dtos.jugadorparecido;
 
-import com.recreadejuerga.recrea.dtos.jugador.JugadorDTO;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.UUID;
 
@@ -12,6 +8,7 @@ import java.util.UUID;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class JugadorParecidoDTO {
     private UUID id;
     private UUID jugadorId;

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/dtos/jugadorparecido/JugadorParecidoInsertarDTO.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/dtos/jugadorparecido/JugadorParecidoInsertarDTO.java
@@ -2,17 +2,14 @@ package com.recreadejuerga.recrea.dtos.jugadorparecido;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.UUID;
-
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class JugadorParecidoInsertarDTO {
 
     @NotNull

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/dtos/jugadorparecido/JugadorParecidoModificarDTO.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/dtos/jugadorparecido/JugadorParecidoModificarDTO.java
@@ -2,13 +2,13 @@ package com.recreadejuerga.recrea.dtos.jugadorparecido;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class JugadorParecidoModificarDTO {
 
     @NotNull

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/dtos/jugadorparecido/JugadorParecidoSimpleDTO.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/dtos/jugadorparecido/JugadorParecidoSimpleDTO.java
@@ -1,9 +1,6 @@
 package com.recreadejuerga.recrea.dtos.jugadorparecido;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.UUID;
 
@@ -11,6 +8,7 @@ import java.util.UUID;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class JugadorParecidoSimpleDTO {
     private UUID id;
     private String parecido;

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/dtos/partido/PartidoDTO.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/dtos/partido/PartidoDTO.java
@@ -1,0 +1,28 @@
+package com.recreadejuerga.recrea.dtos.partido;
+
+import com.recreadejuerga.recrea.dtos.equipo.EquipoDTO;
+import com.recreadejuerga.recrea.dtos.jugador.JugadorDTO;
+import com.recreadejuerga.recrea.dtos.jugador.JugadorSimpleDTO;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PartidoDTO {
+
+    private UUID id;
+    private LocalDateTime fecha;
+    private String lugar;
+    private String estado;
+    private EquipoDTO equipoLocal;
+    private EquipoDTO equipoVisitante;
+    private Integer golesLocal;
+    private Integer golesVisitante;
+    private JugadorSimpleDTO mvp;
+
+}

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/dtos/partido/PartidoFormularioDTO.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/dtos/partido/PartidoFormularioDTO.java
@@ -1,0 +1,39 @@
+package com.recreadejuerga.recrea.dtos.partido;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PartidoFormularioDTO {
+
+    @NotNull
+    private LocalDateTime fecha;
+
+    @NotNull
+    @Size(max = 100)
+    private String lugar;
+
+    @NotNull
+    @Size(max = 20)
+    private String estado;
+
+    @NotNull
+    private UUID equipoLocalId;
+
+    @NotNull
+    private UUID equipoVisitanteId;
+
+    private Integer golesLocal;
+
+    private Integer golesVisitante;
+
+    private UUID mvpId;
+}

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/error/GlobalErrorControlador.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/error/GlobalErrorControlador.java
@@ -128,5 +128,25 @@ public class GlobalErrorControlador extends ResponseEntityExceptionHandler {
         return resultado;
     }
 
+    @ExceptionHandler(PartidoNoEncontradoException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ProblemDetail handlePartidoNoEncontrado(PartidoNoEncontradoException ex, WebRequest request){
+        ProblemDetail resultado= ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, ex.getMessage());
+        resultado.setTitle("Partido no encontrado");
+        resultado.setType(URI.create("https://api.recreadejuerga.com/errores/partido-no-encontrado"));
+        resultado.setInstance(URI.create(request.getDescription(false).replace("uri=", "")));
+        return resultado;
+    }
+
+    @ExceptionHandler(PartidoYaExistenteException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ProblemDetail handlePartidoNoEncontrado(PartidoYaExistenteException ex, WebRequest request){
+        ProblemDetail resultado= ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, ex.getMessage());
+        resultado.setTitle("Partido ya existente");
+        resultado.setType(URI.create("https://api.recreadejuerga.com/errores/partido-ya-existente"));
+        resultado.setInstance(URI.create(request.getDescription(false).replace("uri=", "")));
+        return resultado;
+    }
+
 
 }

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/error/PartidoNoEncontradoException.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/error/PartidoNoEncontradoException.java
@@ -1,0 +1,14 @@
+package com.recreadejuerga.recrea.error;
+
+import java.util.UUID;
+
+public class PartidoNoEncontradoException extends RuntimeException {
+
+    public PartidoNoEncontradoException(String nombreEquipo) {
+        super("No hemos encontrado ningún partido de"+ nombreEquipo);
+    }
+
+    public PartidoNoEncontradoException(UUID partido_id) {
+        super("No hemos encontrado el partido con id("+partido_id+")");
+    }
+}

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/error/PartidoYaExistenteException.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/error/PartidoYaExistenteException.java
@@ -1,0 +1,11 @@
+package com.recreadejuerga.recrea.error;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public class PartidoYaExistenteException extends RuntimeException {
+
+    public PartidoYaExistenteException(LocalDateTime fecha,String lugar) {
+        super("Lo siento, pero ya hay un partido programado el "+fecha +" en "+ lugar);
+    }
+}

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/mappers/JugadorMapper.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/mappers/JugadorMapper.java
@@ -2,6 +2,7 @@ package com.recreadejuerga.recrea.mappers;
 
 import com.recreadejuerga.recrea.dtos.jugador.JugadorDTO;
 import com.recreadejuerga.recrea.dtos.jugador.JugadorFormularioDTO;
+import com.recreadejuerga.recrea.dtos.jugador.JugadorSimpleDTO;
 import com.recreadejuerga.recrea.dtos.jugadorparecido.JugadorParecidoSimpleDTO;
 import com.recreadejuerga.recrea.entidades.Jugador;
 
@@ -28,6 +29,17 @@ public class JugadorMapper {
         );
     }
 
+    public static JugadorSimpleDTO jugadorSimpleDTO(Jugador jugador){
+        if (jugador == null) return null;
+        return new JugadorSimpleDTO(
+                jugador.getId(),
+                jugador.getNombre(),
+                jugador.getApodo(),
+                jugador.getDorsal(),
+                jugador.getEquipo().getId()
+        );
+    }
+
     public static Jugador toJugador(JugadorFormularioDTO insertar_jugador) {
         return Jugador.builder()
                 .nombre(insertar_jugador.getNombre())
@@ -44,9 +56,4 @@ public class JugadorMapper {
                 .fotoPose(insertar_jugador.getFotoPose())
                 .build();
     }
-
-
-
-
-
 }

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/mappers/PartidoMapper.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/mappers/PartidoMapper.java
@@ -1,0 +1,43 @@
+package com.recreadejuerga.recrea.mappers;
+
+import com.recreadejuerga.recrea.dtos.equipo.EquipoDTO;
+import com.recreadejuerga.recrea.dtos.jugador.JugadorSimpleDTO;
+import com.recreadejuerga.recrea.dtos.partido.PartidoDTO;
+import com.recreadejuerga.recrea.dtos.partido.PartidoFormularioDTO;
+import com.recreadejuerga.recrea.entidades.Equipo;
+import com.recreadejuerga.recrea.entidades.Jugador;
+import com.recreadejuerga.recrea.entidades.Partido;
+
+public class PartidoMapper {
+
+    public static PartidoDTO toPartidoDTO(Partido partido){
+        if (partido == null) return null;
+        EquipoDTO equipoLocal=EquipoMapper.toEquipoDTO(partido.getEquipoLocal());
+        EquipoDTO equipoVisitante=EquipoMapper.toEquipoDTO(partido.getEquipoVisitante());
+        JugadorSimpleDTO mvp=JugadorMapper.jugadorSimpleDTO(partido.getMvp());
+        return new PartidoDTO(
+                partido.getId(),
+                partido.getFecha(),
+                partido.getLugar(),
+                partido.getEstado(),
+                equipoLocal,
+                equipoVisitante,
+                partido.getGolesLocal(),
+                partido.getGolesVisitante(),
+                mvp
+        );
+    }
+
+    public static Partido toPartido(PartidoFormularioDTO dto, Equipo equipoLocal, Equipo equipoVisitante, Jugador mvp) {
+        return Partido.builder()
+                .fecha(dto.getFecha())
+                .lugar(dto.getLugar())
+                .estado(dto.getEstado())
+                .equipoLocal(equipoLocal)
+                .equipoVisitante(equipoVisitante)
+                .golesLocal(dto.getGolesLocal())
+                .golesVisitante(dto.getGolesVisitante())
+                .mvp(mvp)
+                .build();
+    }
+}

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/repositorios/PartidoRepositorio.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/repositorios/PartidoRepositorio.java
@@ -1,0 +1,67 @@
+package com.recreadejuerga.recrea.repositorios;
+
+import com.recreadejuerga.recrea.entidades.Equipo;
+import com.recreadejuerga.recrea.entidades.Jugador;
+import com.recreadejuerga.recrea.entidades.Partido;
+import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface PartidoRepositorio extends JpaRepository<Partido, UUID> {
+
+    @Query("""
+            SELECT p
+            FROM Partido p
+            WHERE p.equipoLocal.id = :equipo_id OR p.equipoVisitante.id = :equipo_id
+            ORDER BY p.fecha ASC
+          """)
+    List<Partido> getPartidosDeUnEquipo(@Param("equipo_id") UUID equipo_id);
+
+    @Query("""
+            SELECT p
+            FROM Partido p
+            WHERE p.fecha = :fecha
+            AND LOWER(p.lugar) = LOWER(:lugar)
+        """)
+    Optional<Partido> buscarPorFechaYLugar(
+            @Param("fecha") LocalDateTime fecha,
+            @Param("lugar") String lugar
+    );
+
+
+    @Modifying
+    @Transactional
+    @Query("""
+            UPDATE Partido p SET
+            p.fecha = :fecha,
+            p.lugar = :lugar,
+            p.estado = :estado,
+            p.equipoLocal = :equipoLocal,
+            p.equipoVisitante = :equipoVisitante,
+            p.golesLocal = :golesLocal,
+            p.golesVisitante = :golesVisitante,
+            p.mvp = :mvp
+            WHERE p.id = :id
+           """)
+    void actualizarPartido(
+            @Param("id") UUID id,
+            @Param("fecha") LocalDateTime fecha,
+            @Param("lugar") String lugar,
+            @Param("estado") String estado,
+            @Param("equipoLocal") Equipo equipoLocal,
+            @Param("equipoVisitante") Equipo equipoVisitante,
+            @Param("golesLocal") Integer golesLocal,
+            @Param("golesVisitante") Integer golesVisitante,
+            @Param("mvp") Jugador mvp
+    );
+
+}

--- a/backend/recrea/src/main/java/com/recreadejuerga/recrea/servicios/PartidoServicio.java
+++ b/backend/recrea/src/main/java/com/recreadejuerga/recrea/servicios/PartidoServicio.java
@@ -1,0 +1,138 @@
+package com.recreadejuerga.recrea.servicios;
+
+
+import com.recreadejuerga.recrea.dtos.partido.PartidoDTO;
+import com.recreadejuerga.recrea.dtos.partido.PartidoFormularioDTO;
+import com.recreadejuerga.recrea.entidades.Equipo;
+import com.recreadejuerga.recrea.entidades.Jugador;
+import com.recreadejuerga.recrea.entidades.Partido;
+import com.recreadejuerga.recrea.error.*;
+import com.recreadejuerga.recrea.mappers.PartidoMapper;
+import com.recreadejuerga.recrea.repositorios.EquipoRepositorio;
+import com.recreadejuerga.recrea.repositorios.JugadorRepositorio;
+import com.recreadejuerga.recrea.repositorios.PartidoRepositorio;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+public class PartidoServicio {
+
+    @Autowired
+    private PartidoRepositorio repo;
+
+    @Autowired
+    private JugadorRepositorio repoJugador;
+
+    @Autowired
+    private EquipoRepositorio repoEquipo;
+
+    @Autowired
+    private EquipoServicio equipoServicio;
+
+    public List<PartidoDTO> getPartidosDeUnEquipo(UUID equipo_id){
+        List<Partido> partidos= repo.getPartidosDeUnEquipo(equipo_id);
+        if (partidos.isEmpty()){
+            String nombreEquipo= equipoServicio.getEquipo(equipo_id).getNombre();
+            throw new PartidoNoEncontradoException(nombreEquipo);
+        }
+        return partidos.stream().map(PartidoMapper::toPartidoDTO).toList();
+    }
+
+    public PartidoDTO insertarPartido(PartidoFormularioDTO dto) {
+        if (repo.buscarPorFechaYLugar(dto.getFecha(),dto.getLugar()).isPresent()) {
+            throw new PartidoYaExistenteException(dto.getFecha(),dto.getLugar());
+        }
+        Jugador jugador = null;
+        Equipo equipoLocal = null;
+        Equipo equipoVisitante = null;
+        try {
+             jugador= repoJugador.findById(dto.getMvpId()).orElseThrow(() -> new JugadorNoEncontradoException(dto.getMvpId()));
+             equipoLocal= repoEquipo.findById(dto.getEquipoLocalId()).orElseThrow(()->new EquipoNoEncontradoException(dto.getEquipoLocalId()));
+             equipoVisitante= repoEquipo.findById(dto.getEquipoVisitanteId()).orElseThrow(()->new EquipoNoEncontradoException(dto.getEquipoVisitanteId()));
+            Partido partido = PartidoMapper.toPartido(dto,equipoLocal,equipoVisitante,jugador);
+            return PartidoMapper.toPartidoDTO(repo.save(partido));
+        } catch (DataIntegrityViolationException ex) {
+            Throwable causa = ex.getRootCause();
+            if (causa != null) {
+                String mensaje = causa.getMessage();
+                if (mensaje.contains("uk_fecha_lugar")) {
+                    throw new CamposDuplicadosException(Map.of(
+                            "fecha-lugar", "Ya está programado un partido el día "+ dto.getFecha() +" en "+dto.getLugar()
+                    ));
+                }
+                if (mensaje.contains("uk_partido_equipo_local_equipo_visitante")) {
+                    throw new CamposDuplicadosException(Map.of(
+                            "equipo-local-visitante",  "Ya existe un partido con " + equipoLocal.getNombre() + " como local y " +
+                                    equipoVisitante.getNombre() + " como visitante"
+                    ));
+                }
+                if (mensaje.contains("partidos_estado_check")) {
+                    throw new CamposDuplicadosException(Map.of(
+                            "estado", "El estado debe ser 'Pendiente' o 'Finalizado'"
+                    ));
+                }
+            }
+            throw new CamposDuplicadosException(Map.of(
+                    "desconocido", "Violación de restricción de unicidad"
+            ));
+        }
+    }
+
+    public PartidoDTO modificarPartido(PartidoFormularioDTO dto, UUID id) {
+        if (repo.existsById(id)) {
+            Jugador jugador = null;
+            Equipo equipoLocal = null;
+            Equipo equipoVisitante = null;
+            try {
+                jugador= repoJugador.findById(dto.getMvpId()).orElseThrow(() -> new JugadorNoEncontradoException(dto.getMvpId()));
+                equipoLocal= repoEquipo.findById(dto.getEquipoLocalId()).orElseThrow(()->new EquipoNoEncontradoException(dto.getEquipoLocalId()));
+                equipoVisitante= repoEquipo.findById(dto.getEquipoVisitanteId()).orElseThrow(()->new EquipoNoEncontradoException(dto.getEquipoVisitanteId()));
+                repo.actualizarPartido(id,dto.getFecha(), dto.getLugar(), dto.getEstado(),equipoLocal,equipoVisitante,dto.getGolesLocal(),dto.getGolesVisitante(),jugador);
+                return repo.findById(id).map(PartidoMapper::toPartidoDTO).orElseThrow(() -> new PartidoNoEncontradoException(id));
+            } catch (DataIntegrityViolationException ex) {
+                Throwable causa = ex.getRootCause();
+                if (causa != null) {
+                    String mensaje = causa.getMessage();
+                    if (mensaje.contains("uk_fecha_lugar")) {
+                        throw new CamposDuplicadosException(Map.of(
+                                "fecha-lugar", "Ya está programado un partido el día "+ dto.getFecha() +" en "+dto.getLugar()
+                        ));
+                    }
+                    if (mensaje.contains("uk_partido_equipo_local_equipo_visitante")) {
+                        throw new CamposDuplicadosException(Map.of(
+                                "equipo-local-visitante",  "Ya existe un partido con " + equipoLocal.getNombre() + " como local y " +
+                                        equipoVisitante.getNombre() + " como visitante"
+                        ));
+                    }
+                    if (mensaje.contains("partidos_estado_check")) {
+                        throw new CamposDuplicadosException(Map.of(
+                                "estado", "El estado debe ser 'Pendiente' o 'Finalizado'"
+                        ));
+                    }
+                }
+                throw new CamposDuplicadosException(Map.of(
+                        "desconocido", "Violación de restricción de unicidad"
+                ));
+            }
+        } else {
+            throw new JugadorNoEncontradoException(id);
+        }
+    }
+
+    public boolean eliminarPartido(UUID id) {
+        if (repo.existsById(id)) {
+            repo.deleteById(id);
+            return true;
+        } else {
+            throw new PartidoNoEncontradoException(id);
+        }
+    }
+
+
+
+}


### PR DESCRIPTION
Este Pull Request incorpora toda la lógica de negocio, DTOs, mapeo y controlador para la gestión de partidos en la aplicación. Se establece el flujo completo de creación, edición, consulta y eliminación de partidos, con validaciones y control de errores.

Cambios incluidos

Servicio PartidoServicio con inserción, actualización y obtención de partidos

Repositorio PartidoRepositorio con queries personalizadas

DTOs:

PartidoDTO

PartidoFormularioDTO

Mapper PartidoMapper

Controlador PartidoControlador con endpoints REST documentados

Validaciones y errores:

PartidoYaExistenteException

PartidoNoEncontradoException

Manejo de errores por restricción de unicidad y estado inválido

Refactor de DTOs de jugador y equipo para alinearse con el nuevo modelo

Endpoints

GET /partidos/equipo/{equipoId} – Obtener partidos por equipo

POST /partidos – Crear partido

PUT /partidos/{id} – Modificar partido

DELETE /partidos/{id} – Eliminar partido

Validaciones clave

Fecha y lugar únicos

Combinación equipo local + visitante única

Estado permitido: Pendiente o Finalizado

Manejo de mvpId, equipoLocalId, equipoVisitanteId como UUIDs válidos

Notas

Incluye ejemplos Swagger con @ExampleObject para entrada y salida

Separación clara de commits entre lógica de negocio y refactor de DTOs

